### PR TITLE
Fix readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Returns 'today', 'tomorrow' or 'yesterday', as appropriate, otherwise format the
 Returns a relative time to the current time, seconds as the most granular up to years to the least granular.
 
 ####humanize.ordinal(integer)####
-Converts a number into its [ordinal representation](http://en.wikipedia.org/wiki/Ordinal_number_\(linguistics\)).
+Converts a number into its [ordinal representation](https://en.wikipedia.org/wiki/Ordinal_number_%28linguistics%29).
 
 ####humanize.filesize(filesize [, kilo = 1024, decimals = 2, decPoint = '.', thousandsSep = ',']) ####
 Converts a byte count to a human readable value using kilo as the basis, and numberFormat formatting


### PR DESCRIPTION
The main issue with your link is that, while github understands the format, the [npm](https://www.npmjs.org/package/humanize) readme display does not. It gives the broken link: http://en.wikipedia.org/wiki/Ordinal_number_/(linguistics/

I changed it to https too; no harm in doing so I believe.

Note that parenthesis are invalid in a url anyways and should always be percent encoded, as this pull request does.

Thanks for the great project!
