### PR TITLE
Tell bower to ignore the specs/ directory

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "humanize",
   "version": "0.0.9",
+  "ignore": [
+    "specs/"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/taijinlee/humanize"


### PR DESCRIPTION
I spent some time at work today tracking down why our test suite had broken, and it was because these specs were getting picked up by our Karma config.

Seems like they shouldn't be part of humanize when it's included as a dependency.
