### PR TITLE
Enable custom unit names parameter for filesize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Returns a relative time to the current time, seconds as the most granular up to 
 ####humanize.ordinal(integer)####
 Converts a number into its [ordinal representation](http://en.wikipedia.org/wiki/Ordinal_number_\(linguistics\)).
 
-####humanize.filesize(filesize [, kilo = 1024, decimals = 2, decPoint = '.', thousandsSep = ',']) ####
+####humanize.filesize(filesize [, kilo = 1024, decimals = 2, decPoint = '.', thousandsSep = ',', suffixSep = ' ', units = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB']]) ####
 Converts a byte count to a human readable value using kilo as the basis, and numberFormat formatting
 
 ####humanize.linebreaks(string)####

--- a/humanize.js
+++ b/humanize.js
@@ -232,7 +232,7 @@
 
       // Seconds since UNIX epoch
       U: function () { return jsdate.getTime() / 1000 || 0; }
-    };    
+    };
 
     return format.replace(formatChr, formatChrCb);
   };
@@ -385,12 +385,13 @@
    * For example:
    * If value is 123456789, the output would be 117.7 MB.
    */
-  humanize.filesize = function(filesize, kilo, decimals, decPoint, thousandsSep, suffixSep) {
+  humanize.filesize = function(filesize, kilo, decimals, decPoint, thousandsSep, suffixSep, units) {
+    units = units || ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
     kilo = (kilo === undefined) ? 1024 : kilo;
     if (filesize <= 0) { return '0 bytes'; }
     if (filesize < kilo && decimals === undefined) { decimals = 0; }
     if (suffixSep === undefined) { suffixSep = ' '; }
-    return humanize.intword(filesize, ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'], kilo, decimals, decPoint, thousandsSep, suffixSep);
+    return humanize.intword(filesize, units, kilo, decimals, decPoint, thousandsSep, suffixSep);
   };
 
   /**
@@ -425,7 +426,7 @@
   /**
    * Replaces line breaks in plain text with appropriate HTML
    * A single newline becomes an HTML line break (<br />) and a new line followed by a blank line becomes a paragraph break (</p>).
-   * 
+   *
    * For example:
    * If value is Joel\nis a\n\nslug, the output will be <p>Joel<br />is a</p><p>slug</p>
    */


### PR DESCRIPTION
Hi!

This enables to define custom unit names for Humanize.filesize() by adding a 'units' parameter as shown here:

```
Humanize.filesize(1024, 1024, 1, '.', ',', ' ', ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']);
```

This PR also includes a correction to the README.md .

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/taijinlee/humanize/17)

<!-- Reviewable:end -->
